### PR TITLE
Replace login button with anchor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -237,10 +237,10 @@
                 </nav>
 
                 <div class="user-controls">
-                    <button class="btn btn-primary" id="loginButton" style="display: flex;">
+                    <a href="/auth/steam" class="btn btn-primary" id="loginButton" style="display: flex;">
                         <i class="fa-brands fa-steam"></i>
                         <span>Sign in with Steam</span>
-                    </button>
+                    </a>
 
                     <div class="user-profile-container">
                         <span id="pending-offer-indicator" class="pending-offer-indicator" style="display: none;" title="You have a pending trade offer!">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1671,10 +1671,7 @@ function setupEventListeners() {
     DOMElements.nav.fairLink?.addEventListener('click', (e) => { e.preventDefault(); showPage(DOMElements.pages.fairPage); });
 
 
-    // User controls
-    DOMElements.user.loginButton?.addEventListener('click', () => {
-        window.location.href = '/auth/steam';
-    });
+    // User controls (login button is now a direct link)
     // ... (user profile dropdown, logout unchanged) ...
     const { userProfile, userDropdownMenu, logoutButton, profileDropdownButton, winningHistoryDropdownButton } = DOMElements.user;
     userProfile?.addEventListener('click', (e) => { e.stopPropagation(); if (userDropdownMenu) { const isVisible = userDropdownMenu.style.display === 'block'; userDropdownMenu.style.display = isVisible ? 'none' : 'block'; userProfile?.setAttribute('aria-expanded', String(!isVisible)); userProfile?.classList.toggle('open', !isVisible); } });


### PR DESCRIPTION
## Summary
- switch the login element to an anchor that points to `/auth/steam`
- drop the JS click handler and note that the anchor handles the redirect

## Testing
- `npm test` *(fails: Missing script)*