### PR TITLE
Reset round state client-side and notify completion

### DIFF
--- a/app.js
+++ b/app.js
@@ -637,10 +637,13 @@ async function endRound() {
         // Pass the populated winner object and the final items (after tax)
         await sendWinningTradeOffer(completedRound, winnerInfo, finalItems);
 
+        io.emit('roundCompleted', { roundId: round.roundId });
+
     } catch (err) {
         console.error(`CRITICAL ERROR during endRound for round ${roundIdToEnd}:`, err);
         await Round.updateOne({ _id: roundMongoId }, { $set: { status: 'error', payoutOfferStatus: 'Failed' } }).catch(e => console.error("Error marking round as error after endRound failure:", e));
         io.emit('roundError', { roundId: roundIdToEnd, error: 'Internal server error during round finalization.' });
+        io.emit('roundCompleted', { roundId: roundIdToEnd });
     } finally {
         isRolling = false;
         console.log(`Scheduling next round creation after round ${roundIdToEnd} finalization.`);

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1534,6 +1534,10 @@ function resetToJackpotView() {
         });
         initiateNewRoundVisualReset();
         updateDepositButtonState();
+        if (currentRound) {
+            currentRound.items = [];
+            currentRound.participants = [];
+        }
         if (socket?.connected) {
             console.log("Requesting fresh round data after reset to jackpot view.");
             socket.emit('requestRoundData');


### PR DESCRIPTION
## Summary
- wipe out cached items and participants after resetting the view
- emit `roundCompleted` when a round finishes so clients can reset

## Testing
- `node --check app.js`
- `node --check public/js/main.js`
